### PR TITLE
[hotfix] 사용자 존재여부 확인 시 NOT_FOUND 에러코드 케이스 추가

### DIFF
--- a/src/main/java/com/gapple/backend/authentication/controller/AuthController.java
+++ b/src/main/java/com/gapple/backend/authentication/controller/AuthController.java
@@ -31,7 +31,7 @@ public class AuthController {
             @RequestParam(value = "email") String email
     ) {
 
-        return ResponseEntity.ok(ApiResponse.success(userService.isExistsByEmail(email)));
+        return ResponseEntity.ok(ApiResponse.success(userService.checkExistsByEmail(email)));
     }
 
     @PostMapping("/oauth/signup")

--- a/src/main/java/com/gapple/backend/authentication/service/UserService.java
+++ b/src/main/java/com/gapple/backend/authentication/service/UserService.java
@@ -42,9 +42,15 @@ public class UserService {
         return userRepository.save(user);
     }
 
-    public boolean isExistsByEmail(String email) {
+    public boolean checkExistsByEmail(String email) {
 
-        return userRepository.existsByEmail(email);
+        boolean isUserExist = userRepository.existsByEmail(email);
+
+        if (isUserExist) {
+            return true;
+        } else {
+            throw new CustomException(ErrorCode.NOT_FOUND);
+        }
     }
 
     public boolean isExistsByIdAndEmail(NaverUserProfile profile) {


### PR DESCRIPTION
### Description
사용자 존재여부 확인 Api (/auth/exists) 에서 요청한 사용자 이메일 데이터값이 DB에 없으면 `NOT_FOUND, 404` 에러코드를 반환합니다.